### PR TITLE
add `exports` field and expose `/CustomAttributeRegistry` entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"type": "module",
+	"exports": {
+		".": "./dist/index.js",
+		"./CustomAttributeRegistry": "./dist/CustomAttributeRegistry.js"
+	},
 	"scripts": {
 		"LUME SCRIPTS XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX": "",
 		"clean": "lume clean",


### PR DESCRIPTION
This adds an [`"exports"` field](https://nodejs.org/api/packages.html#package-entry-points) to the `package.json`, which is necessary for this package to be properly usable in an ESM environment.

Exposes two entrypoints, which can be used as follows:


```js
// all of these will execute side-effects from index.js
import "@lume/custom-attributes";
import { customAttributes } from "@lume/custom-attributes";
import { CustomAttributeRegistry } from "@lume/custom-attributes";
```

```js
// imports directly from dist/CustomAttributeRegistry.js
import { CustomAttributeRegistry } from "@lume/custom-attributes/CustomAttributeRegistry";
```